### PR TITLE
Use ido completion as default if ido-mode is enabled

### DIFF
--- a/emamux.el
+++ b/emamux.el
@@ -57,7 +57,7 @@
   :type  'boolean
   :group 'emamux)
 
-(defcustom emamux:completing-read-type (if (featurep 'ido)
+(defcustom emamux:completing-read-type (if ido-mode
                                            'ido
                                          'normal)
   "Function type to call for completing read.


### PR DESCRIPTION
This is better than `(featurep 'ido)`.
