### PR TITLE
Implement default map

### DIFF
--- a/emamux.el
+++ b/emamux.el
@@ -424,6 +424,35 @@ For helm completion use either `normal' or `helm' and turn on `helm-mode'."
   (emamux:check-runner-alive)
   (emamux:tmux-run-command nil "resize-pane" "-Z" "-t" emamux:runner-pane-id))
 
+(defvar emamux:keymap
+  (let ((map (make-sparse-keymap)))
+    (define-key map "\C-s" #'emamux:send-command)
+    (define-key map "\C-y" #'emamux:yank-from-list-buffers)
+    (when (emamux:in-tmux-p)
+      (define-key map "\M-!" #'emamux:run-command)
+      (define-key map "\M-r" #'emamux:run-last-command)
+      (define-key map "\C-i" #'emamux:inspect-runner)
+      (define-key map "\C-k" #'emamux:close-panes)
+      (define-key map "\C-c" #'emamux:interrupt-runner)
+      (define-key map "\M-k" #'emamux:clear-runner-history))
+    map)
+  "Default keymap for emamux commands. Use like
+\(global-set-key (kbd \"M-g\") emamux:keymap\)
+
+Keymap:
+
+| Key | Command                       |
+|-----+-------------------------------|
+| C-s | emamux:send-command           |
+| C-y | emamux:yank-from-list-buffers |
+| M-! | emamux:run-command            |
+| M-r | emamux:run-last-command       |
+| C-i | emamux:inspect-runner         |
+| C-k | emamux:close-panes            |
+| C-c | emamux:interrupt-runner       |
+| M-k | emamux:clear-runner-history   |
+")
+
 (provide 'emamux)
 
 ;;; emamux.el ends here


### PR DESCRIPTION
This is related to #23.
CC: @Yuki-Inoue

You can use default keymap by following configuration.
```
(global-set-key (kbd "M-g") emamux:keymap)
```

Please tell me if you have better key-sequence than this PR.