### PR TITLE
Method to clone frame to new tmux window

### DIFF
--- a/emamux.el
+++ b/emamux.el
@@ -448,6 +448,20 @@ For helm completion use either `normal' or `helm' and turn on `helm-mode'."
 (defun emamux:current-active-window-id ()
   (emamux:active-window-id (emamux:list-windows)))
 
+(defvar emamux:cloning-window-state nil)
+
+;;;###autoload
+(defun emamux:clone-current-frame ()
+  "Clones current frame into a new tmux window."
+  (interactive)
+  (setq emamux:cloning-window-state (window-state-get (frame-root-window)))
+  (emamux:tmux-run-command nil "new-window")
+  (let ((new-window-id (emamux:current-active-window-id))
+        (chdir-cmd (format " cd %s" default-directory))
+        (emacsclient-cmd " emacsclient -nw -e '(window-state-put emamux:cloning-window-state)'"))
+    (emamux:send-keys chdir-cmd new-window-id)
+    (emamux:send-keys emacsclient-cmd new-window-id)))
+
 (defvar emamux:keymap
   (let ((map (make-sparse-keymap)))
     (define-key map "\C-s" #'emamux:send-command)
@@ -459,7 +473,8 @@ For helm completion use either `normal' or `helm' and turn on `helm-mode'."
       (define-key map "\C-k" #'emamux:close-panes)
       (define-key map "\C-c" #'emamux:interrupt-runner)
       (define-key map "\M-k" #'emamux:clear-runner-history)
-      (define-key map "c"    #'emamux:new-window))
+      (define-key map "c"    #'emamux:new-window)
+      (define-key map "C"    #'emamux:clone-current-frame))
     map)
   "Default keymap for emamux commands. Use like
 \(global-set-key (kbd \"M-g\") emamux:keymap\)
@@ -477,6 +492,7 @@ Keymap:
 | C-c | emamux:interrupt-runner       |
 | M-k | emamux:clear-runner-history   |
 | c   | emamux:new-window             |
+| C   | emamux:clone-current-frame    |
 ")
 
 (provide 'emamux)


### PR DESCRIPTION
emamux:clone-current-frame is like a elscreen-clone: it makes a new tmux
window and copies the current emacs window configuration.