### PR TITLE
Fix emacsclient command line to restoree winconf.

### DIFF
--- a/emamux.el
+++ b/emamux.el
@@ -457,7 +457,7 @@ For helm completion use either `normal' or `helm' and turn on `helm-mode'."
   (emamux:tmux-run-command nil "new-window")
   (let ((new-window-id (emamux:current-active-window-id))
         (chdir-cmd (format " cd %s" default-directory))
-        (emacsclient-cmd " emacsclient -nw -e '(window-state-put emamux:cloning-window-state)'"))
+        (emacsclient-cmd " emacsclient -t -e '(run-with-timer 0.01 nil (lambda () (window-state-put emamux:cloning-window-state nil (quote safe))))'"))
     (emamux:send-keys chdir-cmd new-window-id)
     (emamux:send-keys emacsclient-cmd new-window-id)))
 


### PR DESCRIPTION
* emamux.el (emamux:clone-current-frame): Do it.
Run window-state-put in a timer and use the IGNORE arg to avoid
error.