### PR TITLE
Fix get-buffers, show-buffers with last tmux versions.

### DIFF
--- a/emamux.el
+++ b/emamux.el
@@ -72,6 +72,13 @@ For helm completion use either `normal' or `helm' and turn on `helm-mode'."
                  (const :tag "Using ido-completing-read" 'ido)
                  (const :tag "Using helm completion" 'helm)))
 
+(defcustom emamux:get-buffers-regexp
+  "^\\([0-9]+\\): +\\([0-9]+\\) +\\(bytes\\): +[\"]\\(.*\\)[\"]"
+  "Regexp used to match buffers entries in output of tmux command `get-buffers'.
+The entry selected should be the subexp 4 of regexp.
+NOTE that on last version of tmux each line start with \"buffer\"."
+  :type 'regexp)
+
 (defvar emamux:last-command nil
   "Last emit command")
 
@@ -165,8 +172,7 @@ For helm completion use either `normal' or `helm' and turn on `helm-mode'."
     (emamux:tmux-run-command t "list-buffers")
     (goto-char (point-min))
     (cl-loop for count from 0 while
-          (re-search-forward
-           "^\\([0-9]+\\): +\\([0-9]+\\) +\\(bytes\\): +[\"]\\(.*\\)[\"]" nil t)
+          (re-search-forward emamux:get-buffers-regexp nil t)
           collect (cons (replace-regexp-in-string
                          "\\s\\" "" (match-string-no-properties 4))
                         count))))


### PR DESCRIPTION
On last tmux versions the output of `get-buffers` is like this:

`"buffer0010: 5 bytes: \"hello\"`

So the matching regexp should be:

`"^\\(buffer[0-9]+\\): +\\([0-9]+\\) +\\(bytes\\): +[\"]\\(.*\\)[\"]"`

And the `show-buffers` command expect a string as argument, not anymore an index (number), so
e.g `show-buffer -b 0` fails, it expect now `show-buffers -b "buffer0010"` to fit with exemple above.

This pull request allows customizing the regexp and the behavior (use index or not).
The default values are as before (old tmux).